### PR TITLE
Simplify link import.

### DIFF
--- a/create_digiroad_pgdump.sh
+++ b/create_digiroad_pgdump.sh
@@ -54,7 +54,7 @@ docker run -it --rm --link "${DOCKER_CONTAINER_NAME}":postgres $DOCKER_IMAGE_NAM
 SCHEMA_NAME="digiroad"
 TABLE_REF="${SCHEMA_NAME}.dr_linkki_k"
 PGDUMP_OUTPUT="digiroad_k_$(date "+%Y-%m-%d").pgdump"
-SHP2PGSQL="shp2pgsql -D -i -s 3067 -N abort -W UTF-8"
+SHP2PGSQL="shp2pgsql -D -i -s 3067 -S -N abort -W UTF-8"
 
 docker exec "${DOCKER_CONTAINER_NAME}" sh -c "$PSQL -nt -c 'CREATE SCHEMA ${SCHEMA_NAME};'"
 

--- a/sql/transform_dr_linkki_k.sql
+++ b/sql/transform_dr_linkki_k.sql
@@ -2,52 +2,52 @@ DROP TABLE IF EXISTS digiroad.dr_linkki_out;
 
 CREATE TABLE digiroad.dr_linkki_out AS
 SELECT
-    src.gid AS gid,
-    src.link_id AS link_id,
-    src.link_mmlid AS link_mmlid,
-    src.segm_id AS segm_id,
-    src.kuntakoodi AS kuntakoodi,
-    src.hallinn_lk AS hallinn_lk,
-    src.toiminn_lk AS toiminn_lk,
-    src.linkkityyp AS linkkityyp,
-    src.tienumero AS tienumero,
-    src.tieosanro AS tieosanro,
-    src.silta_alik AS silta_alik,
-    src.ajorata AS ajorata,
-    src.aet AS aet,
-    src.let AS let,
-    src.ajosuunta AS ajosuunta,
-    src.tienimi_su AS tienimi_su,
-    src.tienimi_ru AS tienimi_ru,
-    src.tienimi_sa AS tienimi_sa,
-    src.ens_talo_o AS ens_talo_o,
-    src.ens_talo_v AS ens_talo_v,
-    src.viim_tal_o AS viim_tal_o,
-    src.viim_tal_v AS viim_tal_v,
-    src.muokkauspv AS muokkauspv,
-    src.sij_tark AS sij_tark,
-    src.kor_tark AS kor_tark,
-    src.alku_paalu AS alku_paalu,
-    src.lopp_paalu AS lopp_paalu,
-    src.geom_flip AS geom_flip,
-    src.link_tila AS link_tila,
-    src.geom_lahde AS geom_lahde,
-    src.mtk_tie_lk AS mtk_tie_lk,
-    src.tien_kasvu AS tien_kasvu,
-    (ST_Dump(src.geom)).geom AS geom_dump
+    src.gid,
+    src.link_id,
+    src.link_mmlid,
+    src.segm_id,
+    src.kuntakoodi,
+    src.hallinn_lk,
+    src.toiminn_lk,
+    src.linkkityyp,
+    src.tienumero,
+    src.tieosanro,
+    src.silta_alik,
+    src.ajorata,
+    src.aet,
+    src.let,
+    src.ajosuunta,
+    src.tienimi_su,
+    src.tienimi_ru,
+    src.tienimi_sa,
+    src.ens_talo_o,
+    src.ens_talo_v,
+    src.viim_tal_o,
+    src.viim_tal_v,
+    src.muokkauspv,
+    src.sij_tark,
+    src.kor_tark,
+    src.alku_paalu,
+    src.lopp_paalu,
+    src.geom_flip,
+    src.link_tila,
+    src.geom_lahde,
+    src.mtk_tie_lk,
+    src.tien_kasvu,
+    src.geom AS geom_orig
 FROM digiroad.dr_linkki_k src;
 
-UPDATE digiroad.dr_linkki_out SET geom_dump = ST_SetSRID(geom_dump, 3067);
+UPDATE digiroad.dr_linkki_out SET geom_orig = ST_SetSRID(geom_orig, 3067);
 
 SELECT AddGeometryColumn('digiroad', 'dr_linkki_out', 'geom', 3067, 'LINESTRING', 3);
-UPDATE digiroad.dr_linkki_out SET geom = ST_Force3D(geom_dump);
+UPDATE digiroad.dr_linkki_out SET geom = ST_Force3D(geom_orig);
 ALTER TABLE digiroad.dr_linkki_out ALTER COLUMN geom SET NOT NULL;
 
 ALTER TABLE digiroad.dr_linkki_out ADD COLUMN geog geography(LINESTRINGZ, 4326);
 UPDATE digiroad.dr_linkki_out SET geog = Geography(ST_Transform(geom, 4326));
 ALTER TABLE digiroad.dr_linkki_out ALTER COLUMN geog SET NOT NULL;
 
-ALTER TABLE digiroad.dr_linkki_out DROP COLUMN geom_dump;
+ALTER TABLE digiroad.dr_linkki_out DROP COLUMN geom_orig;
 
 -- Replace input table with transformed output.
 DROP TABLE digiroad.dr_linkki_k;


### PR DESCRIPTION
The "-S" option makes shp2pgsql generate simple Geometries instead of MULTIgeometries (LINESTRINGs instead of MULTILINESTRINGs) which is desirable for us.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-digiroad-import-experiment/3)
<!-- Reviewable:end -->
